### PR TITLE
Fix sessionDuration evaluation

### DIFF
--- a/background.js
+++ b/background.js
@@ -26,8 +26,8 @@ async function assumeRoleWithSAML(principalArn, roleArn, sessionDuration, samlAs
   formData.append("RoleArn", roleArn)
   formData.append("SAMLAssertion", samlAssertion)
   if(sessionDuration == Math.ceil(sessionDuration)
-      && 300 < sessionDuration
-      && sessionDuration > 86400
+      && 300 <= sessionDuration
+      && sessionDuration <= 86400
   ){
     formData.append("DurationSeconds", sessionDuration)
   }


### PR DESCRIPTION
Current code on master is ignoring sessionDuration supplied by SAMLDocument because of wrong condition evaluation logic. Now this fixed.